### PR TITLE
Clarify EIP-3085 and EIP-3326 support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ export const ethereum = walletLink.makeWeb3Provider(DEFAULT_ETH_JSONRPC_URL, DEF
 export const web3 = new Web3(ethereum as any)
 ```
 
-Walletlink will use an rpcUrl provided by Coinbase Wallet clients regardless of the rpcUrl passed into `makeWeb3Provider` 
-for whitelisted networks. Walletlink solely needs an rpcUrl to be provided by the dapp as a fallback.
+Walletlink uses an rpcUrl provided by Coinbase Wallet clients regardless of the rpcUrl passed into `makeWeb3Provider` 
+for whitelisted networks. Walletlink needs an rpcUrl to be provided by the dapp as a fallback.
 
-For more information on using alternate networks, please see EIP-3085 and EIP-3326 section below.
+For more information on using alternate networks, please see the section on EIP-3085 and EIP-3326 below.
 
 ### Use EIP-1102 to obtain authorization and get Ethereum accounts
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ export const ethereum = walletLink.makeWeb3Provider(DEFAULT_ETH_JSONRPC_URL, DEF
 export const web3 = new Web3(ethereum as any)
 ```
 
-Walletlink will use an rpcUrl provided by Coinbase Wallet clients regardless of the the rpcUrl passed into `makeWeb3Provider` 
+Walletlink will use an rpcUrl provided by Coinbase Wallet clients regardless of the rpcUrl passed into `makeWeb3Provider` 
 for whitelisted networks. Walletlink solely needs an rpcUrl to be provided by the dapp as a fallback.
 
 For more information on using alternate networks, please see EIP-3085 and EIP-3326 section below.
@@ -99,17 +99,26 @@ That's it! Once the authorization is obtained from the user, the Web3 object
 
 ### Switching / Adding Alternative EVM-Compatible Chains with EIP-3085 and EIP-3326
 
+For dapps supporting multiple networks, only 1 rpcUrl needs to be provided to walletlink. And that is 
+the rpcUrl of the chain the dapp wishes to default users to.
+
 Walletlink and Coinbase Wallet clients support both EIP-3085 `wallet_addEthereumChain` and EIP-3326 
-`wallet_switchEthereumChain` requests for whitelisted networks.
+`wallet_switchEthereumChain` requests for switching networks.
+
+If walletlink receives either a `wallet_switchEthereumChain` or `wallet_addEthereumChain` request for a whitelisted 
+network, then it will switch the user to that network after asking approval from the user.
 
 Current whitelisted networks are Ethereum, Optimism, Polygon, Avalanche, Arbitrum, Fantom, Binance Smart Chain, xDai,
 Arbitrum Rinkeby, Avalanche Fuji, Binance Smart Chain Testnet, Fantom Testnet, Gorli, Kovan, Optimistic Kovan,
 Polygon Mumbai, Rinkeby, and Ropsten.
 
+Beginning February 7, Coinbase Wallet clients will handle `wallet_addEthereumChain` requests for non-whitelisted
+networks. Until then, `wallet_addEthereumChain` requests for non-whitelisted networks will be rejected.
+
 A dapp can determine if a network is whitelisted or not by sending a `wallet_switchEthereumChain` request for
 that network. If error code 4092 is returned, then the network is not supported by default by the client wallet.
 
-Here's how to request the wallet switch to an alternative network:
+Here's how to request the wallet switch networks:
 
 ```
 await ethereum.request({
@@ -159,9 +168,6 @@ supported. Here's an example:
       }
     }
 ```
-
-Beginning on February 7, Coinbase Wallet clients will handle `wallet_addEthereumChain` requests for non-whitelisted
-networks. Until then, `wallet_addEthereumChain` requests for non-whitelisted networks will be rejected.
 
 ### Disconnecting / De-establishing a link
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ Arbitrum Rinkeby, Avalanche Fuji, Binance Smart Chain Testnet, Fantom Testnet, G
 Polygon Mumbai, Rinkeby, and Ropsten.
 
 Beginning February 7, Coinbase Wallet clients will handle `wallet_addEthereumChain` requests for non-whitelisted
-networks. Until then, `wallet_addEthereumChain` requests for non-whitelisted networks will be rejected.
+networks (eg a network such as `Harmony One` which is not supported by clients by default today). 
+Until then, `wallet_addEthereumChain` requests for non-whitelisted networks will be rejected.
 
 A dapp can determine if a network is whitelisted or not by sending a `wallet_switchEthereumChain` request for
 that network. If error code 4092 is returned, then the network is not supported by default by the client wallet.


### PR DESCRIPTION
Have seen a few tickets such as https://github.com/walletlink/walletlink/issues/286 pop up where folks are confused about how to support networks other than eth mainnet using walletlink. This adds a section to the docs to explain how to best use Wallet for any evm-compatible network.