### PR TITLE
Remove backwards compatibility code

### DIFF
--- a/js/src/provider/WalletLinkProvider.ts
+++ b/js/src/provider/WalletLinkProvider.ts
@@ -7,7 +7,6 @@ import BN from "bn.js"
 import { ethErrors } from "eth-rpc-errors"
 
 import { WalletLinkAnalytics } from "../connection/WalletLinkAnalytics"
-import { EthereumChain } from "../EthereumChain"
 import { EVENTS, WalletLinkAnalyticsAbstract } from "../init"
 import { ScopedLocalStorage } from "../lib/ScopedLocalStorage"
 import { EthereumTransactionParams } from "../relay/EthereumTransactionParams"

--- a/js/src/provider/WalletLinkProvider.ts
+++ b/js/src/provider/WalletLinkProvider.ts
@@ -261,16 +261,6 @@ export class WalletLinkProvider
       nativeCurrency
     ).promise
 
-    if (typeof res.result === "boolean") {
-      // legacy handling. to be deprecated in february 2022
-      if (res.result === true) {
-        this._storage.setItem(HAS_CHAIN_BEEN_SWITCHED_KEY, "true")
-        this.updateProviderInfo(rpcUrls[0], chainId, false)
-      }
-
-      return res.result === true
-    }
-
     if (res.result?.isApproved === true) {
       this._storage.setItem(HAS_CHAIN_BEEN_SWITCHED_KEY, "true")
       this.updateProviderInfo(rpcUrls[0], chainId, false)
@@ -293,20 +283,10 @@ export class WalletLinkProvider
       })
     }
 
-    if (typeof res.result !== "boolean") {
-      const switchResponse = res.result as SwitchResponse
-      if (switchResponse.isApproved && switchResponse.rpcUrl.length > 0) {
-        this._storage.setItem(HAS_CHAIN_BEEN_SWITCHED_KEY, "true")
-        this.updateProviderInfo(switchResponse.rpcUrl, chainId, false)
-      }
-    } else {
-      // this is for legacy clients that return a boolean as result. can deprecate below in February 2022
-      if (res.result) {
-        this._storage.setItem(HAS_CHAIN_BEEN_SWITCHED_KEY, "true")
-        const ethereumChain = EthereumChain.fromChainId(BigInt(chainId))!
-        const rpcUrl = EthereumChain.rpcUrl(ethereumChain) ?? ""
-        this.updateProviderInfo(rpcUrl, chainId, false)
-      }
+    const switchResponse = res.result as SwitchResponse
+    if (switchResponse.isApproved && switchResponse.rpcUrl.length > 0) {
+      this._storage.setItem(HAS_CHAIN_BEEN_SWITCHED_KEY, "true")
+      this.updateProviderInfo(switchResponse.rpcUrl, chainId, false)
     }
   }
 

--- a/js/src/relay/Web3Response.ts
+++ b/js/src/relay/Web3Response.ts
@@ -28,7 +28,7 @@ export type RequestEthereumAccountsResponse = BaseWeb3Response<
   AddressString[] // an array of ethereum addresses
 >
 
-export type AddEthereumChainResponse = BaseWeb3Response<AddResponse | boolean> // was request approved
+export type AddEthereumChainResponse = BaseWeb3Response<AddResponse> // was request approved
 
 export type AddResponse = {
   isApproved: boolean

--- a/js/src/relay/Web3Response.ts
+++ b/js/src/relay/Web3Response.ts
@@ -44,9 +44,7 @@ export function AddEthereumChainResponse(
   }
 }
 
-export type SwitchEthereumChainResponse = BaseWeb3Response<
-  SwitchResponse | boolean
-> // was request approved
+export type SwitchEthereumChainResponse = BaseWeb3Response<SwitchResponse> // was request approved
 
 export type SwitchResponse = {
   isApproved: boolean


### PR DESCRIPTION
`AddEthereumChainResponse` and `SwitchEthereumChainResponse` had handling for two types of response that can come from the clients. New clients start rolling out on Monday February 7. It'll take 2-4 weeks for our next walletlink update to percolate to dapps, which is the amount of time needed for new clients to hit 99% adoption.