### PR TITLE
Only mark session as in unlinked error state if it was linked previously

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "walletlink",
-  "version": "2.4.6",
+  "version": "2.4.7",
   "description": "WalletLink JavaScript SDK",
   "keywords": [
     "cipher",

--- a/js/src/relay/WalletLinkRelay.ts
+++ b/js/src/relay/WalletLinkRelay.ts
@@ -141,13 +141,18 @@ export class WalletLinkRelay extends WalletLinkRelayAbstract {
               LOCAL_STORAGE_ADDRESSES_KEY
             )
 
+            if (linked) {
+              // Only set linked session variable one way
+              this.session.linked = linked
+            }
+
             this.isUnlinkedErrorState = false
 
             if (cachedAddresses) {
               const addresses = cachedAddresses.split(" ") as AddressString[]
               const wasConnectedViaStandalone =
                 this.storage.getItem("IsStandaloneSigning") === "true"
-              if (addresses[0] !== "" && !linked) {
+              if (addresses[0] !== "" && !linked && this.session.linked) {
                 if (!wasConnectedViaStandalone) {
                   this.isUnlinkedErrorState = true
                   const sessionIdHash = this.getSessionIdHash()


### PR DESCRIPTION
There was a bug where we mark a session as in unlinked error state.  In the case where a session was established via the extension, the linked flag being false is a normal state.  The flag will remain false until the user opens the mobile app.